### PR TITLE
Typo fixes

### DIFF
--- a/scripts/data/apis/communication.json
+++ b/scripts/data/apis/communication.json
@@ -399,7 +399,7 @@
           "updatedAt": {
             "type": "string",
             "format": "date-time",
-            "description": "Data da ultima edição da publicação",
+            "description": "Data da última edição da publicação",
             "readOnly": true
           },
           "type": {
@@ -428,7 +428,7 @@
                     },
                     "kind": {
                       "type": "string",
-                      "description": "Tipo do publico especificado. Pode ser user, member, group ou tag."
+                      "description": "Tipo do público especificado. Pode ser user, member, group ou tag."
                     }
                   }
                 },
@@ -441,7 +441,7 @@
                     },
                     "kind": {
                       "type": "string",
-                      "description": "Tipo do publico especificado. Pode ser user, member, group ou tag."
+                      "description": "Tipo do público especificado. Pode ser user, member, group ou tag."
                     }
                   }
                 },
@@ -588,7 +588,7 @@
       "Roles": {
         "name": "roles",
         "in": "query",
-        "description": "Permissão que o usuário possui.",
+        "description": "Permissão que o usuário possui",
         "required": false,
         "schema": {
           "type": "string"
@@ -615,7 +615,7 @@
       "QueryId": {
         "name": "userId",
         "in": "query",
-        "description": "Identificador do documento.",
+        "description": "Identificador do documento",
         "required": false,
         "schema": {
           "type": "string"
@@ -645,7 +645,7 @@
       "Tags": {
         "name": "tags",
         "in": "query",
-        "description": "Array contendo os identificadores de todo publico alvo que pode ver essa publicação (grupos, usuarios, alunos e turmas)",
+        "description": "Array contendo os identificadores de todo público alvo que pode ver essa publicação (grupos, usuários, alunos e turmas)",
         "required": false,
         "schema": {
           "type": "array",

--- a/scripts/data/apis/data.json
+++ b/scripts/data/apis/data.json
@@ -2164,7 +2164,7 @@
       "Tags": {
         "name": "tags",
         "in": "query",
-        "description": "Array contendo os identificadores de todo publico alvo que pode ver essa publicação (grupos, usuarios, alunos e turmas)",
+        "description": "Array contendo os identificadores de todo público alvo que pode ver essa publicação (grupos, usuários, alunos e turmas)",
         "required": false,
         "schema": {
           "type": "array",

--- a/scripts/data/apis/oauth.json
+++ b/scripts/data/apis/oauth.json
@@ -179,7 +179,7 @@
               "lastSeenAt": {
                 "type": "string",
                 "format": "date-time",
-                "description": "Data da ultima vez que o usuário visualizou o app"
+                "description": "Data da última vez que o usuário visualizou o app"
               },
               "id": {
                 "type": "string",
@@ -212,7 +212,7 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "description": "permissões de usuário na comunidade"
+                  "description": "Permissões de usuário na comunidade"
                 }
               }
             }
@@ -271,7 +271,7 @@
                 },
                 "season": {
                   "type": "string",
-                  "description": "Periodo escolar ao qual o grupo pertence",
+                  "description": "Período escolar ao qual o grupo pertence",
                   "example": 2020
                 },
                 "enrollment": {
@@ -340,7 +340,7 @@
                 "id": {
                   "type": "string",
                   "format": "ObjectId",
-                  "description": "Identificador do membrp"
+                  "description": "Identificador do membro"
                 },
                 "groups": {
                   "type": "array",
@@ -374,7 +374,7 @@
                       },
                       "season": {
                         "type": "string",
-                        "description": "Periodo escolar ao qual o grupo pertence",
+                        "description": "Período escolar ao qual o grupo pertence",
                         "example": 2020
                       },
                       "enrollment": {

--- a/scripts/data/apis/oauth.json
+++ b/scripts/data/apis/oauth.json
@@ -198,7 +198,7 @@
               },
               "Alias": {
                 "type": "string",
-                "description": "Identidicador do usuário na comunidade",
+                "description": "Identificador do usuário na comunidade",
                 "example": "user1"
               },
               "roles": {

--- a/scripts/data/apis/tickets.json
+++ b/scripts/data/apis/tickets.json
@@ -643,7 +643,7 @@
                 "items": {
                   "type": "string",
                   "format": "ObjectId",
-                  "description": "Identidicador da tag"
+                  "description": "Identificador da tag"
                 }
               }
             }
@@ -843,7 +843,7 @@
               "id": {
                 "type": "string",
                 "format": "ObjectId",
-                "description": "Identidicador do canal de atendimento"
+                "description": "Identificador do canal de atendimento"
               },
               "name": {
                 "type": "string",

--- a/src/pages/concepts/funcionalidades/hub-de-apis.md
+++ b/src/pages/concepts/funcionalidades/hub-de-apis.md
@@ -22,7 +22,7 @@ A troca de informações entre apps do Layers começa com o app que necessita de
 
 + <strong> 2 - Layers repassa a requisição </strong>
 
-Uma vez que o Layers recebe a requisição, o corpo é válidado de acordo com o protocolo da action. Se o formato da requisição estiver de acordo com o formato especificado o Layers repassa a requisição para o provedor especificado como parâmetro na URL adicionando informações de contexto da requisição.
+Uma vez que o Layers recebe a requisição, o corpo é válidado de acordo com o protocolo da action. Se o formato da requisição estiver de acordo com o formato especificado, o Layers repassa a requisição para o provedor especificado como parâmetro na URL adicionando informações de contexto da requisição.
 
 + <strong> 3 - App responde a requisição </strong>
 

--- a/src/pages/concepts/funcionalidades/hub-de-apis.md
+++ b/src/pages/concepts/funcionalidades/hub-de-apis.md
@@ -22,7 +22,7 @@ A troca de informações entre apps do Layers começa com o app que necessita de
 
 + <strong> 2 - Layers repassa a requisição </strong>
 
-Uma vez que o Layers recebe a requisição, o corpo é válidado de acordo com o protocolo da action. Se o formato da requisição estiver de acordo com o formato especificado, o Layers repassa a requisição para o provedor especificado como parâmetro na URL adicionando informações de contexto da requisição.
+Uma vez que o Layers recebe a requisição, o corpo é validado de acordo com o protocolo da action. Se o formato da requisição estiver de acordo com o formato especificado, o Layers repassa a requisição para o provedor especificado como parâmetro na URL adicionando informações de contexto da requisição.
 
 + <strong> 3 - App responde a requisição </strong>
 
@@ -36,6 +36,6 @@ Ao receber a resposta do provedor, o Layers verifica se ela está de acordo com 
 
 A [referência do Hub de APIs](./../../api/apihub/@layerscalendargetrelated/post) tem descritas todas as actions suportadas hoje pela Layers descrevendo o formato de requisição que apps provedores devem receber e qual deve ser o formato da resposta devem retornar.
 
-Para cada uma dessas actions, está disponível um app desenvolvido pela Layers que disponibiliza essas informações. Assim, apps provedores podem se responsabilizar apenas em disponibilizar as informações e nossos apps se responsabilizam por expôr essas informações da melhor maneira para os usuários da Layers.
+Para cada uma dessas actions, está disponível um app desenvolvido pela Layers que disponibiliza essas informações. Assim, apps provedores podem se responsabilizar apenas em disponibilizar as informações e nossos apps se responsabilizam por expor essas informações da melhor maneira para os usuários da Layers.
 
 <!-- colocar cards de cada uma das actions disponíveis? -->

--- a/src/pages/concepts/funcionalidades/login-federado.md
+++ b/src/pages/concepts/funcionalidades/login-federado.md
@@ -10,10 +10,10 @@ previousUrl: '/docs/concepts/funcionalidades/notificacoes'
 
 # Login Federado
 
-A funcionalidade de login federado permite que instituições configurem como será feita a autenticação de usuários. Com essa funcionalidade, é possível configurar fluxos de login http ou OAuth personalizados para domínios de e-mail específicos como e-mails google, microsoft ou até da prórpria instituição.
+A funcionalidade de login federado permite que instituições configurem como será feita a autenticação de usuários. Com essa funcionalidade, é possível configurar fluxos de login http ou OAuth personalizados para domínios de e-mail específicos como e-mails google, microsoft ou até da própria instituição.
 
 ## Usando o login federado
 
 Para usar a funcionalidade em sua comunidade é necessário que a instituição de ensino cadastre os domínios de e-mail e os serviços de autenticação externos que vão utilizar entrando em contato com nosso time pelo e-mail suporte@layers.education.
 
-Os serviços de autenticação podem ser Google, Microsoft ou mesmo um serviço interno da escola. Esses serviços serão responsáveis por receber as credênciais do usuário e permitir ou não que ele acesse a Layers além de implementar a funcionalidade de recuperação de senha.
+Os serviços de autenticação podem ser Google, Microsoft ou mesmo um serviço interno da escola. Esses serviços serão responsáveis por receber as credenciais do usuário e permitir ou não que ele acesse a Layers além de implementar a funcionalidade de recuperação de senha.

--- a/src/pages/concepts/instituicoes-de-ensino.md
+++ b/src/pages/concepts/instituicoes-de-ensino.md
@@ -8,7 +8,7 @@ tableOfContents: false
 
 # Layers para Instituições de Ensino
 
-O Layers oferece para instituições de ensino um único ambiente ao qual é possível integrar soluções internas como um sistema de gestão próprio, bem como inserir outras plataformas educacionais por meio de portais ou mesmo automatizar o envio de comunicados e notificações para, alunos, pais e familiares.
+O Layers oferece para instituições de ensino um único ambiente ao qual é possível integrar soluções internas como um sistema de gestão próprio, bem como inserir outras plataformas educacionais por meio de portais ou mesmo automatizar o envio de comunicados e notificações para alunos, pais e familiares.
 
 ## Principais funcionalidades
 

--- a/src/pages/concepts/startups.md
+++ b/src/pages/concepts/startups.md
@@ -8,7 +8,7 @@ tableOfContents: false
 
 # Layers para Startups
 
-O Layers oferece para startups as ferramentas e funcionalidades necessárias para criar e disponibilizar na Layers Store um app para as mais de 100 instituições de ensino que confiam e utilizam nossos serviços. Entre as funcionalidades que apps de startups podem usar estão o login com Layers através do qual é possível acessar informações com o consentimento do usuário, a API de notificações que permite enviar notificar usuários em qualquer plataforma de atualizações no seu app além dos portais, feature que permite que o app seja acessado através do Layers pela comunidade escolar
+O Layers oferece para startups as ferramentas e funcionalidades necessárias para criar e disponibilizar na Layers Store um app para as mais de 100 instituições de ensino que confiam e utilizam nossos serviços. Entre as funcionalidades que apps de startups podem usar estão o login com Layers através do qual é possível acessar informações com o consentimento do usuário, a API de notificações que permite notificar usuários em qualquer plataforma de atualizações no seu app além dos portais, feature que permite que o app seja acessado através do Layers pela comunidade escolar
 
 ## Principais funcionalidades
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -6,7 +6,7 @@ tableOfContents: false
 
 O [ecossistema Layers Education](/docs/concepts/ecossistema-layers) é uma plataforma web e mobile que contém os dados e conecta as soluções educacionais utilizadas por instituições de ensino. Por meio de apps, instituições de ensino podem personalizar sua experiência conectando soluções que já utilizam como ERP's, EdTech's ou mesmo soluções internas.
 
-Para desenvolvedores desse serviços, integrar sua solução ao Layers significa [criar um app](/docs/register) único  com as [funcionalidades disponibilizadas](#funcionalidades-para-apps). Esse app, uma vez revisado e aprovado, poderá ser utilizado por qualquer instituição que utilize o Layers sem necessidade de realizar novas integrações ou desenvolvimento específico para cada instituição.
+Para desenvolvedores desses serviços, integrar sua solução ao Layers significa [criar um app](/docs/register) único  com as [funcionalidades disponibilizadas](#funcionalidades-para-apps). Esse app, uma vez revisado e aprovado, poderá ser utilizado por qualquer instituição que utilize o Layers sem necessidade de realizar novas integrações ou desenvolvimento específico para cada instituição.
 
 ## Segmentos no Layers Education
 <docs-cards>
@@ -53,7 +53,7 @@ O Layers oferece aos desenvolvedores uma série de funcionalidades para que crie
   </docs-card>
 
   <docs-card header="Notificações" href="/docs/concepts/funcionalidades/notificacoes" icon="/docs/assets/icons/Notifications.svg">
-    <p>Mandar notificações push para android, ios e web</p>
+    <p>Mandar notificações push para Android, iOS e Web</p>
   </docs-card>
 
   <docs-card header="Comunicação" href="/docs/concepts/funcionalidades/comunicacao" icon="/docs/assets/icons/Comunicação.svg">

--- a/src/pages/sdk/como-colocar-o-botao-logar-com-layers.md
+++ b/src/pages/sdk/como-colocar-o-botao-logar-com-layers.md
@@ -109,7 +109,7 @@ A API deve retornar um JSON com o seguinte formato:
 ```js
 {
   "access_token": "{{jwtToken}}",
-  "token_type": Number,
+  "token_type": Bearer,
   "expires_in": Number,
   "state": String
 }


### PR DESCRIPTION
Removi alguns small typos no` funcionalidades/login-federado.md` e `startups.md` e achei que cabia uma vírgula no `hub-de-apis.md#Layers-repassa-a-requisição`